### PR TITLE
Optimise performance of Error Info on status bar.

### DIFF
--- a/HotSettings/ErrorStatus/ErrorStatusTextViewCreationListener.cs
+++ b/HotSettings/ErrorStatus/ErrorStatusTextViewCreationListener.cs
@@ -49,5 +49,8 @@
 
         internal IVsStatusbar StatusBarService => this.statusBarService
             ?? (this.statusBarService = this.ServiceProvider.GetService(typeof(SVsStatusbar)) as IVsStatusbar);
+
+        // Keep track of the last error message added to the status bar so we don't clear other messages.
+        internal string LastErrorText { get; set; }
     }
 }

--- a/HotSettings/ReleaseNotes.txt
+++ b/HotSettings/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ﻿Hot Settings
 
-14-Mar-2018 v1.1.6: New feature - Error info on status bar (from Christian Gunderman)
+14-Mar-2018 v1.1.7: New feature - Error info on status bar (from Christian Gunderman)
 20-Jan-2018 v1.1.5: Restored all toolbar buttons
 11-Jan-2017 v1.1.4: Completed all margins and most editor adornments
 26-Dec-2017 v1.1: Added support for Outling and Navigation Bar

--- a/HotSettings/source.extension.vsixmanifest
+++ b/HotSettings/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="HotSettings.Justin Clareburt.9d7d4a40-2b7c-4177-82bf-1876951e6b24" Version="1.1.6" Language="en-US" Publisher="Justin Clareburt" />
+        <Identity Id="HotSettings.Justin Clareburt.9d7d4a40-2b7c-4177-82bf-1876951e6b24" Version="1.1.7" Language="en-US" Publisher="Justin Clareburt" />
         <DisplayName> Hot Settings</DisplayName>
         <Description xml:space="preserve">Menus and Toolbars that expose Visual Studio settings</Description>
         <MoreInfo>https://marketplace.visualstudio.com/items?itemName=JustinClareburtMSFT.HotSettings</MoreInfo>


### PR DESCRIPTION
Stop listening to GotFocus.
Only clear text if it was the text previously set.
Only set text it it's different to the current text.